### PR TITLE
Add admin flag to employee, fix created/updated timestamp columns, and persist apiKeyId

### DIFF
--- a/taco-tuesday-rest-api/src/main/java/com/muskopf/tacotuesday/bl/EmployeeDAO.java
+++ b/taco-tuesday-rest-api/src/main/java/com/muskopf/tacotuesday/bl/EmployeeDAO.java
@@ -8,8 +8,8 @@ import java.util.List;
 public interface EmployeeDAO {
     // Employees
     Employee createEmployee(String fullName, String nickName, String slackId, boolean isAdmin);
-    Employee createEmployee(String fullName, String slackId);
     Employee createEmployee(String fullName, String slackId, boolean isAdmin);
+    Employee createEmployee(String fullName, String slackId);
     Employee createEmployee(Employee employee);
 
     Employee getEmployeeBySlackId(String slackId);

--- a/taco-tuesday-rest-api/src/main/java/com/muskopf/tacotuesday/bl/EmployeeDAO.java
+++ b/taco-tuesday-rest-api/src/main/java/com/muskopf/tacotuesday/bl/EmployeeDAO.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public interface EmployeeDAO {
     // Employees
-	Employee createEmployee(String fullName, String nickName, String slackId, boolean isAdmin);
+    Employee createEmployee(String fullName, String nickName, String slackId, boolean isAdmin);
     Employee createEmployee(String fullName, String slackId);
     Employee createEmployee(String fullName, String slackId, boolean isAdmin);
     Employee createEmployee(Employee employee);

--- a/taco-tuesday-rest-api/src/main/java/com/muskopf/tacotuesday/bl/EmployeeDAO.java
+++ b/taco-tuesday-rest-api/src/main/java/com/muskopf/tacotuesday/bl/EmployeeDAO.java
@@ -1,14 +1,19 @@
 package com.muskopf.tacotuesday.bl;
 
+import com.muskopf.tacotuesday.domain.ApiKey;
 import com.muskopf.tacotuesday.domain.Employee;
 
 import java.util.List;
 
 public interface EmployeeDAO {
     // Employees
-	Employee createEmployee(String fullName, String nickName, String slackId);
+	Employee createEmployee(String fullName, String nickName, String slackId, boolean isAdmin);
+    Employee createEmployee(String fullName, String slackId);
+    Employee createEmployee(String fullName, String slackId, boolean isAdmin);
     Employee createEmployee(Employee employee);
+
     Employee getEmployeeBySlackId(String slackId);
+    Employee registerEmployeeApiKey(Employee employee);
     List<Employee> getAllEmployees();
 
     // API Keys

--- a/taco-tuesday-rest-api/src/main/java/com/muskopf/tacotuesday/bl/impl/EmployeeDAOImpl.java
+++ b/taco-tuesday-rest-api/src/main/java/com/muskopf/tacotuesday/bl/impl/EmployeeDAOImpl.java
@@ -1,8 +1,10 @@
 package com.muskopf.tacotuesday.bl.impl;
 
 import com.muskopf.tacotuesday.bl.EmployeeDAO;
+import com.muskopf.tacotuesday.bl.proc.ApiKeyGenerator;
 import com.muskopf.tacotuesday.bl.repository.ApiKeyRepository;
 import com.muskopf.tacotuesday.bl.repository.EmployeeRepository;
+import com.muskopf.tacotuesday.domain.ApiKey;
 import com.muskopf.tacotuesday.domain.Employee;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -29,8 +31,19 @@ public class EmployeeDAOImpl implements EmployeeDAO {
         return createEmployee(
                 employee.getFullName(),
                 employee.getSlackId(),
-                employee.getNickName()
+                employee.getNickName(),
+                employee.isAdmin()
         );
+    }
+
+    @Override
+    public Employee createEmployee(String fullName, String slackId) {
+        return createEmployee(fullName, slackId, false);
+    }
+
+    @Override
+    public Employee createEmployee(String fullName, String slackId, boolean isAdmin) {
+        return createEmployee(fullName, slackId, null, isAdmin);
     }
 
     @Override
@@ -39,21 +52,32 @@ public class EmployeeDAOImpl implements EmployeeDAO {
     }
 
     @Override
-    public Employee createEmployee(String fullName, String slackId, String nickName) {
+    public Employee registerEmployeeApiKey(Employee employee) {
+        ApiKey apiKey = ApiKeyGenerator.generateForEmployee(employee);
+        apiKey = apiKeyRepository.save(apiKey);
+
+        employee.setApiKey(apiKey);
+
+        return employee;
+    }
+
+    @Override
+    public Employee createEmployee(String fullName, String slackId, String nickName, boolean isAdmin) {
         if (isNull(fullName) || isNull(slackId)) {
             throw new IllegalArgumentException("Full Name and Slack ID are required when creating an employee!");
         }
 
-        boolean employeeAlreadyExists = employeeRepository.existsEmployeeByFullName(fullName);
-        employeeAlreadyExists |= employeeRepository.existsEmployeeBySlackId(slackId);
-        if (employeeAlreadyExists) {
+        if (employeeRepository.existsEmployeeBySlackId(slackId)) {
             throw new EntityExistsException("The requested employee already exists!");
         }
 
         Employee employee = new Employee()
                 .fullName(fullName)
                 .nickName(nickName)
-                .slackId(slackId);
+                .slackId(slackId)
+                .admin(isAdmin);
+
+        registerEmployeeApiKey(employee);
 
         return employeeRepository.save(employee);
     }

--- a/taco-tuesday-rest-api/src/main/java/com/muskopf/tacotuesday/bl/proc/ApiKeyGenerator.java
+++ b/taco-tuesday-rest-api/src/main/java/com/muskopf/tacotuesday/bl/proc/ApiKeyGenerator.java
@@ -5,8 +5,6 @@ import com.muskopf.tacotuesday.domain.Employee;
 
 import java.util.UUID;
 
-import static java.util.Objects.isNull;
-
 public class ApiKeyGenerator {
     private static String getRandomKeyString(Employee employee) {
         return UUID.randomUUID().toString();
@@ -16,7 +14,6 @@ public class ApiKeyGenerator {
         String randomKey = getRandomKeyString(employee);
 
         ApiKey apiKey = new ApiKey();
-        apiKey.setEmployee(employee);
         apiKey.setKey(randomKey);
 
         return apiKey;

--- a/taco-tuesday-rest-api/src/main/java/com/muskopf/tacotuesday/domain/ApiKey.java
+++ b/taco-tuesday-rest-api/src/main/java/com/muskopf/tacotuesday/domain/ApiKey.java
@@ -1,14 +1,23 @@
 package com.muskopf.tacotuesday.domain;
 
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+
 import javax.persistence.*;
 
 @Entity
+@JsonIdentityInfo(
+        generator = ObjectIdGenerators.PropertyGenerator.class,
+        property = "id"
+)
 public class ApiKey {
     @Id
     @GeneratedValue
     private Integer id;
 
-    @OneToOne(mappedBy = "apiKey", fetch = FetchType.LAZY)
+    @OneToOne(mappedBy = "apiKey")
+    @JsonIgnore
     private Employee employee;
 
     @Column(name = "api_key")

--- a/taco-tuesday-rest-api/src/main/java/com/muskopf/tacotuesday/domain/Employee.java
+++ b/taco-tuesday-rest-api/src/main/java/com/muskopf/tacotuesday/domain/Employee.java
@@ -21,15 +21,20 @@ public class Employee {
     @Column(updatable = false)
     @CreationTimestamp
     private Instant createdAt;
+    
     @Column
     @UpdateTimestamp
     private Instant updatedAt;
+    
     @Column(nullable = false)
     private String fullName;
+    
     @Column(unique = true, nullable = false)
     private String slackId;
+    
     @Column
     private String nickName;
+    
     @Column(nullable = false)
     private boolean admin = false;
 

--- a/taco-tuesday-rest-api/src/main/java/com/muskopf/tacotuesday/domain/Employee.java
+++ b/taco-tuesday-rest-api/src/main/java/com/muskopf/tacotuesday/domain/Employee.java
@@ -3,6 +3,7 @@ package com.muskopf.tacotuesday.domain;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.muskopf.tacotuesday.bl.proc.ApiKeyGenerator;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 import javax.persistence.*;
 import java.time.Instant;
@@ -17,14 +18,20 @@ public class Employee {
     @GeneratedValue
     private Integer id;
 
+    @Column(updatable = false)
     @CreationTimestamp
     private Instant createdAt;
+    @Column
+    @UpdateTimestamp
+    private Instant updatedAt;
     @Column(nullable = false)
     private String fullName;
     @Column(unique = true, nullable = false)
     private String slackId;
     @Column
     private String nickName;
+    @Column(nullable = false)
+    private boolean admin = false;
 
     @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
     @JoinColumn(name = "api_key_id", referencedColumnName = "id")
@@ -34,19 +41,24 @@ public class Employee {
     @JsonIgnore
     private List<IndividualOrder> orders;
 
-    @PrePersist
-    public void ensureApiKeyIsPopulated() {
-        if (!isNull(this.apiKey)) {
-            return;
-        }
-
-        this.apiKey = ApiKeyGenerator.generateForEmployee(this);
+    public Integer getId() {
+        return id;
+    }
+    public void setId(Integer id) {
+        this.id = id;
     }
 
     public String getFullName() { return fullName; }
     public void setFullName(String fullName) { this.fullName = fullName; }
     public Employee fullName(String fullName) {
         this.fullName = fullName;
+        return this;
+    }
+
+    public String getSlackId() { return slackId; }
+    public void setSlackId() { this.slackId = slackId; }
+    public Employee slackId(String slackId) {
+        this.slackId = slackId;
         return this;
     }
 
@@ -57,24 +69,20 @@ public class Employee {
         return this;
     }
 
-    public Integer getId() {
-        return id;
+    public boolean isAdmin() { return admin; }
+    public void setAdmin(boolean admin) { this.admin = admin; }
+    public Employee admin(boolean admin) {
+        this.admin = admin;
+        return this;
     }
-    public void setId(Integer id) {
-        this.id = id;
-    }
+
+    public ApiKey getApiKey() { return apiKey; }
+    public void setApiKey(ApiKey apiKey) { this.apiKey = apiKey; }
 
     public List<IndividualOrder> getOrders() { return orders; }
     public void setOrders(List<IndividualOrder> orders) { this.orders = orders; }
     public Employee orders(List<IndividualOrder> orders) {
         this.orders = orders;
-        return this;
-    }
-
-    public String getSlackId() { return slackId; }
-    public void setSlackId() { this.slackId = slackId; }
-    public Employee slackId(String slackId) {
-        this.slackId = slackId;
         return this;
     }
 }


### PR DESCRIPTION
This PR adds the `admin` boolean to the `Employee` object as described in issue #30  .
It also fixes the `Employee`'s created timestamp not being persisted, adds an updated timestamp, and fixes the `Employee` having no reference to its API key.