### PR TITLE
Add actuators to POM

### DIFF
--- a/taco-tuesday-rest-api/pom.xml
+++ b/taco-tuesday-rest-api/pom.xml
@@ -55,6 +55,10 @@
             <artifactId>email-sender</artifactId>
             <version>0.0.1-SNAPSHOT</version>
         </dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>com.h2database</groupId>

--- a/taco-tuesday-rest-api/src/test/java/com/muskopf/tacotuesday/api/TacoTuesdayApiEmployeeRestControllerTests.java
+++ b/taco-tuesday-rest-api/src/test/java/com/muskopf/tacotuesday/api/TacoTuesdayApiEmployeeRestControllerTests.java
@@ -1,0 +1,4 @@
+package com.muskopf.tacotuesday.api;
+
+public class TacoTuesdayApiEmployeeRestControllerTests {
+}

--- a/taco-tuesday-rest-api/src/test/java/com/muskopf/tacotuesday/api/TacoTuesdayApiOrderRestControllerTests.java
+++ b/taco-tuesday-rest-api/src/test/java/com/muskopf/tacotuesday/api/TacoTuesdayApiOrderRestControllerTests.java
@@ -1,0 +1,4 @@
+package com.muskopf.tacotuesday.api;
+
+public class TacoTuesdayApiOrderRestControllerTests {
+}

--- a/taco-tuesday-rest-api/src/test/java/com/muskopf/tacotuesday/api/TacoTuesdayApiTacoRestControllerTests.java
+++ b/taco-tuesday-rest-api/src/test/java/com/muskopf/tacotuesday/api/TacoTuesdayApiTacoRestControllerTests.java
@@ -1,0 +1,4 @@
+package com.muskopf.tacotuesday.api;
+
+public class TacoTuesdayApiTacoRestControllerTests {
+}


### PR DESCRIPTION
Enables the `/actuator/health` endpoint.