### PR TITLE
Enable CORS for GET mappings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea/
 .mvn/
 *.iml
+docs/dist/swagger.json

--- a/taco-tuesday-rest-api/src/main/java/com/muskopf/tacotuesday/api/TacoTuesdayApiEmployeeRestController.java
+++ b/taco-tuesday-rest-api/src/main/java/com/muskopf/tacotuesday/api/TacoTuesdayApiEmployeeRestController.java
@@ -61,6 +61,7 @@ public class TacoTuesdayApiEmployeeRestController {
         return new ResponseEntity<>(mapper.mapEmployeeToEmployeeResource(employee), HttpStatus.CREATED);
     }
 
+    @CrossOrigin
     @ApiOperation(value = "Retrieve all Existing Employees")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Retrieved Successfully", response = EmployeeResource[].class),
@@ -76,6 +77,7 @@ public class TacoTuesdayApiEmployeeRestController {
         return new ResponseEntity<>(mapper.mapEmployeesToEmployeeResources(employees), HttpStatus.OK);
     }
 
+    @CrossOrigin
     @ApiOperation(value = "Retrieve an Employee by Slack ID")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Retrieved Successfully", response = EmployeeResource.class),

--- a/taco-tuesday-rest-api/src/main/java/com/muskopf/tacotuesday/api/TacoTuesdayApiOrderRestController.java
+++ b/taco-tuesday-rest-api/src/main/java/com/muskopf/tacotuesday/api/TacoTuesdayApiOrderRestController.java
@@ -44,6 +44,7 @@ public class TacoTuesdayApiOrderRestController {
         this.emailer = emailer;
     }
 
+    @CrossOrigin
     @ApiOperation(value = "Retrieve all Individual Orders")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Retrieved Successfully", response = IndividualOrderResource[].class),
@@ -63,6 +64,7 @@ public class TacoTuesdayApiOrderRestController {
         return new ResponseEntity<>(mapper.mapIndividualOrdersToIndividualOrderResources(orders), HttpStatus.OK);
     }
 
+    @CrossOrigin
     @ApiOperation(value = "Retrieve an Individual Order by ID")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Retrieved Successfully", response = IndividualOrder.class),
@@ -80,6 +82,7 @@ public class TacoTuesdayApiOrderRestController {
         return new ResponseEntity<>(mapper.mapIndividualOrderToIndividualOrderResource(order), HttpStatus.OK);
     }
 
+    @CrossOrigin
     @ApiOperation(value = "Retrieve all Full Orders")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Retrieved Successfully", response = IndividualOrderResource[].class),
@@ -118,6 +121,7 @@ public class TacoTuesdayApiOrderRestController {
         return new ResponseEntity<>(mapper.mapFullOrderToFullOrderResource(order), HttpStatus.CREATED);
     }
 
+    @CrossOrigin
     @ApiOperation(value = "Retrieve a Full Order by ID")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Retrieved Successfully", response = FullOrderResource.class),

--- a/taco-tuesday-rest-api/src/main/java/com/muskopf/tacotuesday/api/TacoTuesdayApiTacoRestController.java
+++ b/taco-tuesday-rest-api/src/main/java/com/muskopf/tacotuesday/api/TacoTuesdayApiTacoRestController.java
@@ -12,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -33,6 +34,7 @@ public class TacoTuesdayApiTacoRestController {
         this.emailer = emailer;
     }
 
+    @CrossOrigin
     @ApiOperation(value = "Retrieve all Taco Types")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Retrieved Successfully", response = TacoResource[].class),


### PR DESCRIPTION
Add the `@CrossOrigin` annotation to GET endpoints to enable Cross-Origin requests.