### PR TITLE
Issue/57/circleci deploy branch publish swaggerhub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,15 @@ jobs:
       # ...with this image as the primary container; this is where all `steps` will run
       - image: circleci/openjdk:8-jdk-stretch 
     steps: 
+      # check out source code to working directory
+      - checkout: 
+          path: ~/taco_tuesday_backend
+      # restore the saved cache after the first run or if `pom.xml` has changed
+      - restore_cache: 
+          # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
+          key: taco-tuesday-rest-api-{{ checksum "pom.xml" }}
       - run: echo 'deploy world'
+      - run: mvn package -DbuildNumber=${CIRCLE_BUILD_NUM}
   publish_swagger:
     # directory where steps will run
     working_directory: ~/taco_tuesday_backend/taco-tuesday-rest-api
@@ -56,7 +64,6 @@ jobs:
       # check out source code to working directory
       - checkout: 
           path: ~/taco_tuesday_backend
-      - run: echo 'publish_swagger world'
       - run: mvn compile swaggerhub:upload 
 
 workflows:
@@ -68,7 +75,7 @@ workflows:
             branches:
               ignore:
                 - issue/57/circleci-deploy-branch-publish-swaggerhub
-      - publish_swagger:
+      - deploy:
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
           command: |
             mkdir ../artifacts
             cp target/taco-tuesday-rest-api-0.0.${CIRCLE_BUILD_NUM}-SNAPSHOT.jar ../artifacts/ 
-            cp ../docs ../artifacts/
+            cp -r ../docs ../artifacts/
       # uploads the test metadata from the `target/surefire-reports` directory so that it can show up in the CircleCI dashboard. 
       - store_test_results: 
           # Upload test results for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,10 +32,6 @@ jobs:
           # Upload test results for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
           path: target/surefire-reports
       
-      - store_artifacts: # store the uberjar as an artifact
-          # Upload test summary for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
-          path: target/taco-tuesday-rest-api-0.0.${CIRCLE_BUILD_NUM}-SNAPSHOT.jar
-      # See https://circleci.com/docs/2.0/deployment-integrations/ for deploy examples 
   deploy:
     # directory where steps will run
     working_directory: ~/taco_tuesday_backend/taco-tuesday-rest-api
@@ -54,6 +50,14 @@ jobs:
       - run: echo 'deploy world'
       - run: mvn dependency:go-offline 
       - run: mvn package -DbuildNumber=${CIRCLE_BUILD_NUM}
+      # uploads the test metadata from the `target/surefire-reports` directory so that it can show up in the CircleCI dashboard. 
+      - store_test_results: 
+          # Upload test results for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
+          path: target/surefire-reports
+      - store_artifacts: # store the uberjar as an artifact
+          # Upload test summary for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
+          path: target/taco-tuesday-rest-api-0.0.${CIRCLE_BUILD_NUM}-SNAPSHOT.jar
+  
   publish_swagger:
     # directory where steps will run
     working_directory: ~/taco_tuesday_backend/taco-tuesday-rest-api

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,12 +47,15 @@ jobs:
       - restore_cache: 
           # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
           key: taco-tuesday-rest-api-{{ checksum "pom.xml" }}
-      - run: echo 'deploy world'
       - run: mvn dependency:go-offline 
       - run: mvn package -DbuildNumber=${CIRCLE_BUILD_NUM}
       # Copy jar and docs to artifacts directory
-      - run: cp target/taco-tuesday-rest-api-0.0.${CIRCLE_BUILD_NUM}-SNAPSHOT.jar ../artifacts/ 
-      - run: cp ../docs ../artifacts/
+      - run: 
+          name: Copy Artifacts
+          command: |
+            mkdir ../artifacts
+            cp target/taco-tuesday-rest-api-0.0.${CIRCLE_BUILD_NUM}-SNAPSHOT.jar ../artifacts/ 
+            cp ../docs ../artifacts/
       # uploads the test metadata from the `target/surefire-reports` directory so that it can show up in the CircleCI dashboard. 
       - store_test_results: 
           # Upload test results for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,13 +50,18 @@ jobs:
       - run: echo 'deploy world'
       - run: mvn dependency:go-offline 
       - run: mvn package -DbuildNumber=${CIRCLE_BUILD_NUM}
+      # Copy jar and docs to artifacts directory
+      - run: cp 
+      target/taco-tuesday-rest-api-0.0.${CIRCLE_BUILD_NUM}-SNAPSHOT.jar
+      ../artifacts/ ;
+              cp ../docs ../artifacts/
       # uploads the test metadata from the `target/surefire-reports` directory so that it can show up in the CircleCI dashboard. 
       - store_test_results: 
           # Upload test results for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
           path: target/surefire-reports
       - store_artifacts: # store the uberjar as an artifact
           # Upload test summary for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
-          path: target/
+          path: ../artifacts/
   
   publish_swagger:
     # directory where steps will run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,8 @@ workflows:
               ignore:
                 - deploy-production
       - publish_swagger:
+          requires:
+            - build_and_test
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,10 +51,8 @@ jobs:
       - run: mvn dependency:go-offline 
       - run: mvn package -DbuildNumber=${CIRCLE_BUILD_NUM}
       # Copy jar and docs to artifacts directory
-      - run: cp \
-      target/taco-tuesday-rest-api-0.0.${CIRCLE_BUILD_NUM}-SNAPSHOT.jar
-      ../artifacts/ ; \
-              cp ../docs ../artifacts/
+      - run: cp target/taco-tuesday-rest-api-0.0.${CIRCLE_BUILD_NUM}-SNAPSHOT.jar ../artifacts/ 
+      - run: cp ../docs ../artifacts/
       # uploads the test metadata from the `target/surefire-reports` directory so that it can show up in the CircleCI dashboard. 
       - store_test_results: 
           # Upload test results for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,7 @@ jobs:
           # Upload test summary for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
           path: ../artifacts/
       - run: mvn swaggerhub:upload -DbuildNumber=${CIRCLE_BUILD_NUM}
+      # TODO: FTP/SCP files to Host
 
 workflows:
   version: 2
@@ -73,30 +74,11 @@ workflows:
           filters:
             branches:
               ignore:
-                - issue/57/circleci-deploy-branch-publish-swaggerhub
-      - deploy_and_publish_swagger:
-          filters:
-            branches:
-              ignore:
                 - deploy-production
 
   deploy_production_workflow:
     jobs:
-      - build_and_test:
-          filters:
-            branches:
-              only:
-                - deploy-production
-      - deploy:
-          requires:
-            - build_and_test
-          filters:
-            branches:
-              only:
-                - deploy-production
-      - publish_swagger:
-          requires:
-            - deploy
+      - deploy_and_publish_swagger:
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,9 @@ jobs:
       # ...with this image as the primary container; this is where all `steps` will run
       - image: circleci/openjdk:8-jdk-stretch 
     steps: 
+      # check out source code to working directory
+      - checkout: 
+          path: ~/taco_tuesday_backend
       - run: echo 'publish_swagger world'
       - run: mvn install 
               io.swagger:swaggerhub-maven-plugin:1.0.7:upload 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,8 +59,8 @@ jobs:
       - run: echo 'publish_swagger world'
       - run: mvn install 
               io.swagger:swaggerhub-maven-plugin:1.0.7:upload 
-              owner:Taco-Tuesday 
-              uploadType:inputFile
+              io.swagger:swaggerhub-maven-plugin:1.0.7:owner:Taco-Tuesday 
+              io.swagger:swaggerhub-maven-plugin:1.0.7:uploadType:inputFile
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
           path: target/surefire-reports
       - store_artifacts: # store the uberjar as an artifact
           # Upload test summary for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
-          path: target/taco-tuesday-rest-api-0.0.${CIRCLE_BUILD_NUM}-SNAPSHOT.jar
+          path: target/
   
   publish_swagger:
     # directory where steps will run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
       - checkout: 
           path: ~/taco_tuesday_backend
       - run: echo 'publish_swagger world'
-      - run: mvn swaggerhub:upload 
+      - run: mvn compile swaggerhub:upload 
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           # Upload test results for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
           path: target/surefire-reports
       
-  deploy:
+  deploy_and_publish_swagger:
     # directory where steps will run
     working_directory: ~/taco_tuesday_backend/taco-tuesday-rest-api
     # run the steps with Docker
@@ -63,19 +63,7 @@ jobs:
       - store_artifacts: # store the uberjar as an artifact
           # Upload test summary for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
           path: ../artifacts/
-  
-  publish_swagger:
-    # directory where steps will run
-    working_directory: ~/taco_tuesday_backend/taco-tuesday-rest-api
-    # run the steps with Docker
-    docker: 
-      # ...with this image as the primary container; this is where all `steps` will run
-      - image: circleci/openjdk:8-jdk-stretch 
-    steps: 
-      # check out source code to working directory
-      - checkout: 
-          path: ~/taco_tuesday_backend
-      - run: mvn compile swaggerhub:upload 
+      - run: mvn swaggerhub:upload 
 
 workflows:
   version: 2
@@ -86,7 +74,7 @@ workflows:
             branches:
               ignore:
                 - issue/57/circleci-deploy-branch-publish-swaggerhub
-      - deploy:
+      - deploy_and_publish_swagger:
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,11 +54,10 @@ jobs:
       - image: circleci/openjdk:8-jdk-stretch 
     steps: 
       - run: echo 'publish_swagger world'
-      - run: mvn install \
-              io.swagger:swaggerhub-maven-plugin:1.0.7:upload \
-              owner:Taco-Tuesday
+      - run: mvn install 
+              io.swagger:swaggerhub-maven-plugin:1.0.7:upload 
+              owner:Taco-Tuesday 
               uploadType:inputFile
-              token:${env.SWAGGERHUB_TOKEN}
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,10 +57,7 @@ jobs:
       - checkout: 
           path: ~/taco_tuesday_backend
       - run: echo 'publish_swagger world'
-      - run: mvn install 
-              io.swagger:swaggerhub-maven-plugin:1.0.7:upload 
-              io.swagger:swaggerhub-maven-plugin:1.0.7:owner:Taco-Tuesday 
-              io.swagger:swaggerhub-maven-plugin:1.0.7:uploadType:inputFile
+      - run: mvn swaggerhub:upload 
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,9 +51,9 @@ jobs:
       - run: mvn dependency:go-offline 
       - run: mvn package -DbuildNumber=${CIRCLE_BUILD_NUM}
       # Copy jar and docs to artifacts directory
-      - run: cp 
+      - run: cp \
       target/taco-tuesday-rest-api-0.0.${CIRCLE_BUILD_NUM}-SNAPSHOT.jar
-      ../artifacts/ ;
+      ../artifacts/ ; \
               cp ../docs ../artifacts/
       # uploads the test metadata from the `target/surefire-reports` directory so that it can show up in the CircleCI dashboard. 
       - store_test_results: 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,10 +70,8 @@ workflows:
           filters:
             branches:
               ignore:
-                - deploy-production
+                - issue/57/circleci-deploy-branch-publish-swaggerhub
       - publish_swagger:
-          requires:
-            - build_and_test
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
       - restore_cache: 
           # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
           key: taco-tuesday-rest-api-{{ checksum "pom.xml" }}
-      - run: mvn dependency:go-offline 
+      - run: mvn dependency:go-offline -DbuildNumber=${CIRCLE_BUILD_NUM}
       - run: mvn package -DbuildNumber=${CIRCLE_BUILD_NUM}
       # Copy jar and docs to artifacts directory
       - run: 
@@ -63,7 +63,7 @@ jobs:
       - store_artifacts: # store the uberjar as an artifact
           # Upload test summary for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
           path: ../artifacts/
-      - run: mvn swaggerhub:upload 
+      - run: mvn swaggerhub:upload -DbuildNumber=${CIRCLE_BUILD_NUM}
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ jobs:
           # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
           key: taco-tuesday-rest-api-{{ checksum "pom.xml" }}
       - run: echo 'deploy world'
+      - run: mvn dependency:go-offline 
       - run: mvn package -DbuildNumber=${CIRCLE_BUILD_NUM}
   publish_swagger:
     # directory where steps will run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,12 +54,22 @@ jobs:
       - image: circleci/openjdk:8-jdk-stretch 
     steps: 
       - run: echo 'publish_swagger world'
+      - run: mvn install \
+              io.swagger:swaggerhub-maven-plugin:1.0.7:upload \
+              owner:Taco-Tuesday
+              uploadType:inputFile
+              token:${env.SWAGGERHUB_TOKEN}
 
 workflows:
   version: 2
   build_and_test_workflow:
     jobs:
       - build_and_test:
+          filters:
+            branches:
+              ignore:
+                - deploy-production
+      - publish_swagger:
           filters:
             branches:
               ignore:

--- a/taco-tuesday-rest-api/pom.xml
+++ b/taco-tuesday-rest-api/pom.xml
@@ -10,13 +10,14 @@
     </parent>
     <groupId>com.muskopf.tacotuesday</groupId>
     <artifactId>taco-tuesday-rest-api</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.${buildNumber}-SNAPSHOT</version>
     <name>Taco Tuesday REST API</name>
     <description>A REST API that provides statistics about tacos ordered on Tuesdays.</description>
 
     <properties>
         <java.version>1.8</java.version>
-        <api.version>0.0.1</api.version>
+        <buildNumber>0</buildNumber>
+        <api.version>0.0.${buildNumber}</api.version>
         <org.mapstruct.version>1.3.1.Final</org.mapstruct.version>
         <ttapi.swaggerdir>${project.basedir}${file.separator}..${file.separator}docs${file.separator}dist</ttapi.swaggerdir>
         <ttapi.swaggerfile>swagger</ttapi.swaggerfile>

--- a/taco-tuesday-rest-api/pom.xml
+++ b/taco-tuesday-rest-api/pom.xml
@@ -18,7 +18,7 @@
         <java.version>1.8</java.version>
         <api.version>0.0.1</api.version>
         <org.mapstruct.version>1.3.1.Final</org.mapstruct.version>
-        <ttapi.swaggerdir>${project.basedir}\..\docs\dist</ttapi.swaggerdir>
+        <ttapi.swaggerdir>${project.basedir}${file.separator}..${file.separator}docs${file.separator}dist</ttapi.swaggerdir>
         <ttapi.swaggerfile>swagger</ttapi.swaggerfile>
     </properties>
     

--- a/taco-tuesday-rest-api/pom.xml
+++ b/taco-tuesday-rest-api/pom.xml
@@ -206,7 +206,7 @@
                     <owner>Taco-Tuesday</owner>
                     <version>${api.version}</version>
                     <uploadType>inputFile</uploadType>
-                    <inputFile>${ttapi.swaggerdir}\${ttapi.swaggerfile}.json</inputFile>
+                    <inputFile>${ttapi.swaggerdir}${file.separator}${ttapi.swaggerfile}.json</inputFile>
                     <format>json</format>
                     <token>${env.SWAGGERHUB_TOKEN}</token>
                 </configuration>

--- a/taco-tuesday-rest-api/pom.xml
+++ b/taco-tuesday-rest-api/pom.xml
@@ -198,20 +198,18 @@
                 <version>1.0.7</version>
                 <!-- Change this to command line, not on install
                      only for deploy-production -->
-                <executions>
-                    <execution>
-                        <phase>install</phase>
-                        <configuration>
-                            <api>TacoTuesdayAPI</api>
-                            <owner>Taco-Tuesday</owner>
-                            <version>${api.version}</version>
-                            <uploadType>inputFile</uploadType>
-                            <inputFile>${ttapi.swaggerdir}\${ttapi.swaggerfile}.json</inputFile>
-                            <format>json</format>
-                            <token>${env.SWAGGERHUB_TOKEN}</token>
-                        </configuration>
-                    </execution>
-                </executions>
+                <goals>
+                    <goal>upload</goal>
+                </goals>
+                <configuration>
+                    <api>TacoTuesdayAPI</api>
+                    <owner>Taco-Tuesday</owner>
+                    <version>${api.version}</version>
+                    <uploadType>inputFile</uploadType>
+                    <inputFile>${ttapi.swaggerdir}\${ttapi.swaggerfile}.json</inputFile>
+                    <format>json</format>
+                    <token>${env.SWAGGERHUB_TOKEN}</token>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Seperate CircleCI into two workflows [Issue#57](https://github.com/justinmuskopf/taco_tuesday_backend/issues/57)

**deploy_production_workflow**
It's created for a future branch called `deploy-production`. When a merge occurs on the `deploy-production` branch from (likely) `master` that will start testing, following by storing of the jar file, generated swagger docs, then store the artifacts in CircleCI. Missing tagging Github and deploying to host.

**build_and_test_workflow**
This is for all branches that are not `deploy-production`. The purpose of this workflow is to run the tests and validate that tests pass. It will run on all other branch commits and show be the primary driver of "Red X" and "Green Checkmark"

**Reccomend:** Merge and Squash due to trash in CI development occurring in GitHub