### PR TITLE
Add the summary endpoint

### DIFF
--- a/taco-tuesday-rest-api/src/main/java/com/muskopf/tacotuesday/bl/OrderDAO.java
+++ b/taco-tuesday-rest-api/src/main/java/com/muskopf/tacotuesday/bl/OrderDAO.java
@@ -4,6 +4,7 @@ import com.muskopf.tacotuesday.domain.FullOrder;
 import com.muskopf.tacotuesday.domain.IndividualOrder;
 
 import java.util.List;
+import java.util.Map;
 
 public interface OrderDAO {
     // Individual Orders
@@ -27,6 +28,8 @@ public interface OrderDAO {
     List<FullOrder> retrieveAllFullOrders();
 
     List<FullOrder> retrieveFullOrdersBySlackId(String slackId);
+
+    Map<String, Object> retrieveOrderStatistics();
 
     boolean fullOrderExistsById(Integer id);
 }

--- a/taco-tuesday-rest-api/src/main/java/com/muskopf/tacotuesday/domain/FullOrder.java
+++ b/taco-tuesday-rest-api/src/main/java/com/muskopf/tacotuesday/domain/FullOrder.java
@@ -14,6 +14,8 @@ import java.util.Set;
 @Entity
 @EqualsAndHashCode(callSuper = true)
 public class FullOrder extends Order {
+    public static final String TABLE_NAME = "full_order";
+
     @OneToMany(mappedBy = "fullOrder", fetch = FetchType.EAGER, cascade = CascadeType.MERGE)
     @JsonManagedReference
     private Set<IndividualOrder> individualOrders;

--- a/taco-tuesday-rest-api/src/main/java/com/muskopf/tacotuesday/domain/Order.java
+++ b/taco-tuesday-rest-api/src/main/java/com/muskopf/tacotuesday/domain/Order.java
@@ -4,7 +4,6 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 import javax.persistence.*;
-import java.time.Instant;
 
 @Data
 @MappedSuperclass
@@ -13,21 +12,21 @@ public abstract class Order extends DomainObject {
     @Column
     private Float total;
 
-    @Column
+    @Column(name = "barbacoa")
     private Integer barbacoa = 0;
-    @Column
+    @Column(name = "beef_fajita")
     private Integer beefFajita = 0;
-    @Column
+    @Column(name = "cabeza")
     private Integer cabeza = 0;
-    @Column
+    @Column(name = "carnitas")
     private Integer carnitas = 0;
-    @Column
+    @Column(name = "chicken_fajita")
     private Integer chickenFajita = 0;
-    @Column
+    @Column(name = "lengua")
     private Integer lengua = 0;
-    @Column
+    @Column(name = "pastor")
     private Integer pastor = 0;
-    @Column
+    @Column(name = "tripa")
     private Integer tripa = 0;
 
     public void merge(Order newOrder) {
@@ -43,7 +42,7 @@ public abstract class Order extends DomainObject {
 
     public void setTacoCount(TacoType tacoType, int count) {
         if (count < 0) {
-            throw new RuntimeException("Invalid " + tacoType.getPrettyName() + " Count: " + count + "!");
+            throw new RuntimeException("Invalid " + tacoType.prettyName() + " Count: " + count + "!");
         }
 
         switch (tacoType) {
@@ -72,7 +71,7 @@ public abstract class Order extends DomainObject {
                 this.tripa = count;
                 break;
             default:
-                throw new RuntimeException("Invalid Taco Type: " + tacoType.getPrettyName() + "!");
+                throw new RuntimeException("Invalid Taco Type: " + tacoType.prettyName() + "!");
         }
     }
 
@@ -95,7 +94,7 @@ public abstract class Order extends DomainObject {
             case tripa:
                 return tripa;
             default:
-                throw new RuntimeException("Invalid Taco Type: " + tacoType.getPrettyName() + "!");
+                throw new RuntimeException("Invalid Taco Type: " + tacoType.prettyName() + "!");
         }
     }
 

--- a/taco-tuesday-rest-api/src/main/java/com/muskopf/tacotuesday/domain/Taco.java
+++ b/taco-tuesday-rest-api/src/main/java/com/muskopf/tacotuesday/domain/Taco.java
@@ -15,6 +15,6 @@ public class Taco {
     public Taco(TacoType type, Float price) {
         this.type = type;
         this.price = price;
-        this.name = type.getPrettyName();
+        this.name = type.prettyName();
     }
 }

--- a/taco-tuesday-rest-api/src/main/java/com/muskopf/tacotuesday/domain/TacoType.java
+++ b/taco-tuesday-rest-api/src/main/java/com/muskopf/tacotuesday/domain/TacoType.java
@@ -1,22 +1,23 @@
 package com.muskopf.tacotuesday.domain;
 
 public enum TacoType {
-    barbacoa("Barbacoa"),
-    beefFajita("Beef Fajita"),
-    cabeza("Cabeza"),
-    carnitas("Carnitas"),
-    chickenFajita("Chicken Fajita"),
-    lengua("Lengua"),
-    pastor("Pastor"),
-    tripa("Tripa");
+    barbacoa("Barbacoa", "barbacoa"),
+    beefFajita("Beef Fajita", "beef_fajita"),
+    cabeza("Cabeza", "cabeza"),
+    carnitas("Carnitas", "carnitas"),
+    chickenFajita("Chicken Fajita", "chicken_fajita"),
+    lengua("Lengua", "lengua"),
+    pastor("Pastor", "pastor"),
+    tripa("Tripa", "tripa");
 
     private String prettyName;
+    private String columnName;
 
-    TacoType(String prettyName) {
+    TacoType(String prettyName, String columnName) {
         this.prettyName = prettyName;
+        this.columnName = columnName;
     }
 
-    public String getPrettyName() {
-        return prettyName;
-    }
+    public String prettyName() { return prettyName; }
+    public String columnName() { return columnName; }
 }

--- a/taco-tuesday-rest-api/src/main/java/com/muskopf/tacotuesday/resource/OrderSummaryResource.java
+++ b/taco-tuesday-rest-api/src/main/java/com/muskopf/tacotuesday/resource/OrderSummaryResource.java
@@ -1,0 +1,22 @@
+package com.muskopf.tacotuesday.resource;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.muskopf.tacotuesday.domain.TacoType;
+import lombok.Data;
+
+import java.math.BigInteger;
+import java.util.Map;
+
+@Data
+public class OrderSummaryResource {
+    @JsonProperty
+    private BigInteger individualOrderCount;
+    @JsonProperty
+    private BigInteger fullOrderCount;
+    @JsonProperty
+    private BigInteger tacoCount;
+    @JsonProperty
+    private Double total;
+    @JsonProperty
+    private Map<TacoType, BigInteger> tacos;
+}


### PR DESCRIPTION
Adds the `GET /orders/summary` endpoint.
This endpoint produces a payload similar to this:
```java
@Data
public class OrderSummaryResource {
    @JsonProperty
    private BigInteger individualOrderCount;
    @JsonProperty
    private BigInteger fullOrderCount;
    @JsonProperty
    private BigInteger tacoCount;
    @JsonProperty
    private Double total;
    @JsonProperty
    private Map<TacoType, BigInteger> tacos;
}
```